### PR TITLE
Add a Prepare Job to the Go Integrations Workflow

### DIFF
--- a/.github/workflows/go-integrations.yaml
+++ b/.github/workflows/go-integrations.yaml
@@ -14,6 +14,75 @@ permissions:
   security-events: write
 
 jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: infra/go.mod
+          check-latest: true
+          cache-dependency-path: |
+            .bingo/*.sum
+            infra/go.sum
+
+      - name: Set up NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          check-latest: true
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Cache the Terraform Provider bindings
+        id: cdktf
+        uses: actions/cache@v4
+        with:
+          # Save the .task folder alongside the generated folder to allow task
+          # to record the get task as having been already run, enabling this
+          # step to be bypassed where possible in the testing steps below
+          path: |
+            infra/.task
+            infra/generated
+          key: cache-cdktf-infra-${{ hashFiles('infra/cdktf.json') }}
+
+      - name: Cache the Yarn modules
+        id: yarn
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+          key: cache-yarn-root-${{ hashFiles('yarn.lock') }}
+
+      - name: Install the bingo Go tool
+        run: |-
+          go install \
+            github.com/bwplotka/bingo@latest
+
+      - name: Install the required Go tools
+        run: |-
+          bingo get --link
+
+      - name: Install the required NodeJS tools
+        if: ${{ steps.yarn.outputs.cache-hit != 'true' }}
+        run: |-
+          yarn install \
+            --ignore-engines \
+            --no-progress
+
+      - name: Build the Terraform Provider bindings
+        if: ${{ steps.cdktf.outputs.cache-hit != 'true' }}
+        working-directory: infra
+        run: |-
+          task get \
+            --output group \
+            --output-group-begin '::group::{{ .TASK }}' \
+            --output-group-end '::endgroup::'
+
   linting:
     strategy:
       matrix:
@@ -24,6 +93,8 @@ jobs:
 
     name: Linting
     runs-on: ubuntu-latest
+    needs:
+      - prepare
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
@@ -50,9 +121,6 @@ jobs:
         if: ${{ matrix.module == 'infra' }}
         uses: actions/cache@v4
         with:
-          # Save the .task folder alongside the generated folder to allow task
-          # to record the get task as having been already run, enabling this
-          # step to be bypassed where possible in the testing steps below
           path: |
             infra/.task
             infra/generated
@@ -82,15 +150,6 @@ jobs:
             --ignore-engines \
             --no-progress
 
-      - name: Build the Terraform Provider bindings
-        if: ${{ matrix.module == 'infra' && steps.cdktf.outputs.cache-hit != 'true' }}
-        working-directory: ${{ matrix.module }}
-        run: |-
-          task get \
-            --output group \
-            --output-group-begin '::group::{{ .TASK }}' \
-            --output-group-end '::endgroup::'
-
       - name: Lint the ${{ matrix.module }} Go module
         working-directory: ${{ matrix.module }}
         run: |-
@@ -102,6 +161,8 @@ jobs:
   prettier:
     name: Prettier
     runs-on: ubuntu-latest
+    needs:
+      - prepare
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
@@ -196,9 +257,6 @@ jobs:
         if: ${{ matrix.module == 'infra' }}
         uses: actions/cache@v4
         with:
-          # Save the .task folder alongside the generated folder to allow task
-          # to record the get task as having been already run, enabling this
-          # step to be bypassed where possible in the testing steps below
           path: |
             infra/.task
             infra/generated
@@ -208,9 +266,6 @@ jobs:
         id: yarn
         uses: actions/cache@v4
         with:
-          # Save the .task folder alongside the generated folder to allow task
-          # to record the get task as having been already run, enabling this
-          # step to be bypassed where possible in the testing steps below
           path: |
             node_modules
           key: cache-yarn-root-${{ hashFiles('yarn.lock') }}

--- a/infra/cdktf.json
+++ b/infra/cdktf.json
@@ -8,7 +8,7 @@
     {
       "name": "google",
       "source": "hashicorp/google",
-      "version": "~> 5.12.0"
+      "version": "~> 5.13.0"
     },
     {
       "name": "random",


### PR DESCRIPTION
Add a Prepare job to the Go Integrations Workflow which will manage the pre-processing of the caches for both Yarn and CDKTF before running the remaining steps.

This may add a few seconds for overall processing, but will always ensure the remaining steps are fast, and reduce the duplication of work caches overwriting each other.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [ ] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
